### PR TITLE
Teams index

### DIFF
--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -1,6 +1,24 @@
 class Api::V1::TeamsController < ApplicationController
     def index
-        teams = TeamsFacade.teams
+        TeamsFacade.upsert_teams
+        teams = Team
+            .order(sort_mappings[team_params[:sort]])
+            .all
         render json: teams, status: 200, each_serializer: TeamSerializer
     end
+
+    private
+
+        def team_params
+            params.permit(:sort)
+        end
+
+        def sort_mappings
+            {
+                "name_asc" => "name ASC",
+                "name_desc" => "name DESC",
+                "year_asc" => "inaugural_year ASC",
+                "year_desc" => "inaugural_year DESC",
+            }
+        end
 end

--- a/app/facades/teams_facade.rb
+++ b/app/facades/teams_facade.rb
@@ -2,15 +2,15 @@ class TeamsFacade
     def self.teams
         json = NhlStatsapiService.get_teams
         teams = json[:teams].map do |team_json|
-            team = Team.create(
-                id: team_json[:id],
-                name: team_json[:name],
-                abbr: team_json[:abbreviation],
-                external_url: NhlStatsapiService.base_url + team_json[:link],
-                division: team_json[:division][:name],
-                conference: team_json[:conference][:name],
-                inaugural_year: team_json[:firstYearOfPlay],
-            )
+            team = Team.find_or_initialize_by(id: team_json[:id])
+            team.name = team_json[:name]
+            team.abbr = team_json[:abbreviation]
+            team.external_url = NhlStatsapiService.base_url + team_json[:link]
+            team.division = team_json[:division][:name]
+            team.conference = team_json[:conference][:name]
+            team.inaugural_year = team_json[:firstYearOfPlay]
+            team.save
+            team
         end
     end
 end

--- a/app/facades/teams_facade.rb
+++ b/app/facades/teams_facade.rb
@@ -1,5 +1,5 @@
 class TeamsFacade
-    def self.teams
+    def self.upsert_teams
         json = NhlStatsapiService.get_teams
         teams = json[:teams].map do |team_json|
             team = Team.find_or_initialize_by(id: team_json[:id])

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,6 +2,7 @@ class Team < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :abbr
   validates_presence_of :external_url
+  validates_uniqueness_of :abbr
 
   has_many :players
 end

--- a/spec/fixtures/teams_no_roster.json
+++ b/spec/fixtures/teams_no_roster.json
@@ -39,66 +39,67 @@
             "active" : true
         }, 
         {
-            "id" : 2,
-            "name" : "New York Islanders",
-            "link" : "/api/v1/teams/2",
+            "id" : 21,
+            "name" : "Colorado Avalanche",
+            "link" : "/api/v1/teams/21",
             "venue" : {
-                "name" : "Nassau Veterans Memorial Coliseum",
-                "link" : "/api/v1/venues/null",
-                "city" : "Uniondale",
+                "id" : 5064,
+                "name" : "Ball Arena",
+                "link" : "/api/v1/venues/5064",
+                "city" : "Denver",
                 "timeZone" : {
-                "id" : "America/New_York",
-                "offset" : -4,
-                "tz" : "EDT"
+                    "id" : "America/Denver",
+                    "offset" : -6,
+                    "tz" : "MDT"
                 }
             },
-            "abbreviation" : "NYI",
-            "teamName" : "Islanders",
-            "locationName" : "New York",
-            "firstYearOfPlay" : "1972",
+            "abbreviation" : "COL",
+            "teamName" : "Avalanche",
+            "locationName" : "Colorado",
+            "firstYearOfPlay" : "1979",
             "division" : {
-                "id" : 25,
-                "name" : "MassMutual East",
-                "link" : "/api/v1/divisions/25"
+                "id" : 27,
+                "name" : "Honda West",
+                "link" : "/api/v1/divisions/27"
             },
             "conference" : {
-                "id" : 6,
-                "name" : "Eastern",
-                "link" : "/api/v1/conferences/6"
+                "id" : 5,
+                "name" : "Western",
+                "link" : "/api/v1/conferences/5"
             },
             "franchise" : {
-                "franchiseId" : 22,
-                "teamName" : "Islanders",
-                "link" : "/api/v1/franchises/22"
+                "franchiseId" : 27,
+                "teamName" : "Avalanche",
+                "link" : "/api/v1/franchises/27"
             },
-            "shortName" : "NY Islanders",
-            "officialSiteUrl" : "http://www.newyorkislanders.com/",
-            "franchiseId" : 22,
+            "shortName" : "Colorado",
+            "officialSiteUrl" : "http://www.coloradoavalanche.com/",
+            "franchiseId" : 27,
             "active" : true
         }, 
         {
-            "id" : 3,
-            "name" : "New York Rangers",
-            "link" : "/api/v1/teams/3",
+            "id" : 8,
+            "name" : "Montréal Canadiens",
+            "link" : "/api/v1/teams/8",
             "venue" : {
-                "id" : 5054,
-                "name" : "Madison Square Garden",
-                "link" : "/api/v1/venues/5054",
-                "city" : "New York",
+                "id" : 5028,
+                "name" : "Bell Centre",
+                "link" : "/api/v1/venues/5028",
+                "city" : "Montréal",
                 "timeZone" : {
-                "id" : "America/New_York",
-                "offset" : -4,
-                "tz" : "EDT"
+                    "id" : "America/Montreal",
+                    "offset" : -4,
+                    "tz" : "EDT"
                 }
             },
-            "abbreviation" : "NYR",
-            "teamName" : "Rangers",
-            "locationName" : "New York",
-            "firstYearOfPlay" : "1926",
+            "abbreviation" : "MTL",
+            "teamName" : "Canadiens",
+            "locationName" : "Montréal",
+            "firstYearOfPlay" : "1909",
             "division" : {
-                "id" : 25,
-                "name" : "MassMutual East",
-                "link" : "/api/v1/divisions/25"
+                "id" : 28,
+                "name" : "Scotia North",
+                "link" : "/api/v1/divisions/28"
             },
             "conference" : {
                 "id" : 6,
@@ -106,13 +107,13 @@
                 "link" : "/api/v1/conferences/6"
             },
             "franchise" : {
-                "franchiseId" : 10,
-                "teamName" : "Rangers",
-                "link" : "/api/v1/franchises/10"
+                "franchiseId" : 1,
+                "teamName" : "Canadiens",
+                "link" : "/api/v1/franchises/1"
             },
-            "shortName" : "NY Rangers",
-            "officialSiteUrl" : "http://www.newyorkrangers.com/",
-            "franchiseId" : 10,
+            "shortName" : "Montréal",
+            "officialSiteUrl" : "http://www.canadiens.com/",
+            "franchiseId" : 1,
             "active" : true
         }
     ]

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -5,6 +5,9 @@ describe Team, type: :model do
     it {should validate_presence_of(:name)} 
     it {should validate_presence_of(:abbr)} 
     it {should validate_presence_of(:external_url)} 
+
+    subject {Team.new(name:"Avs", abbr: "COL", external_url:"/avs")}
+    it {should validate_uniqueness_of(:abbr)} 
     
     it {should_not validate_presence_of(:division)} 
     it {should_not validate_presence_of(:conference)} 

--- a/spec/requests/api/v1/teams/index_spec.rb
+++ b/spec/requests/api/v1/teams/index_spec.rb
@@ -31,4 +31,52 @@ describe "Teams Index" do
         get "/api/v1/teams"
         expect(Team.count).to eq 3
     end
+
+    it "can sort results by name ASC and DESC" do
+        get "/api/v1/teams", params: {sort: 'name_asc'}
+
+        teams_json = JSON.parse(response.body)
+
+        expect(teams_json.count).to eq 3
+        team_1_json, team_2_json, team_3_json = teams_json
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+        expect(team_2_json["name"]).to eq "Montréal Canadiens"
+        expect(team_3_json["name"]).to eq "New Jersey Devils"
+
+        get "/api/v1/teams", params: {sort: 'name_desc'}
+        
+        teams_json = JSON.parse(response.body)
+
+        expect(teams_json.count).to eq 3
+        team_1_json, team_2_json, team_3_json = teams_json
+
+        expect(team_1_json["name"]).to eq "New Jersey Devils"
+        expect(team_2_json["name"]).to eq "Montréal Canadiens"
+        expect(team_3_json["name"]).to eq "Colorado Avalanche"
+    end
+
+    it "can sort results by inaugural year ASC and DESC" do
+        get "/api/v1/teams", params: {sort: 'year_asc'}
+
+        teams_json = JSON.parse(response.body)
+
+        expect(teams_json.count).to eq 3
+        team_1_json, team_2_json, team_3_json = teams_json
+
+        expect(team_1_json["inaugural_year"]).to eq 1909
+        expect(team_2_json["inaugural_year"]).to eq 1979
+        expect(team_3_json["inaugural_year"]).to eq 1982
+
+        get "/api/v1/teams", params: {sort: 'year_desc'}
+        
+        teams_json = JSON.parse(response.body)
+
+        expect(teams_json.count).to eq 3
+        team_1_json, team_2_json, team_3_json = teams_json
+
+        expect(team_1_json["inaugural_year"]).to eq 1982
+        expect(team_2_json["inaugural_year"]).to eq 1979
+        expect(team_3_json["inaugural_year"]).to eq 1909
+    end
 end

--- a/spec/requests/api/v1/teams/index_spec.rb
+++ b/spec/requests/api/v1/teams/index_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 describe "Teams Index" do
-    it "can get all existing teams without roster data" do
+    before :each do
         fixture_json = File.read('spec/fixtures/teams_no_roster.json')
-        stub_request(:get, "https://statsapi.web.nhl.com/api/v1/teams").
+        @stub_team_request = stub_request(:get, "https://statsapi.web.nhl.com/api/v1/teams").
             to_return(status: 200, body: fixture_json)
-        
+    end
+
+    it "can get all existing teams without roster data" do
         get "/api/v1/teams"
 
         teams_json = JSON.parse(response.body)
@@ -20,5 +22,13 @@ describe "Teams Index" do
         expect(team_1_json['division']).to be_a(String)
         expect(team_1_json['conference']).to be_a(String)
         expect(team_1_json['inaugural_year']).to be_a(Integer)
+    end
+
+    it "upsert Team records when index endpoint is accessed" do
+        get "/api/v1/teams"
+        expect(Team.count).to eq 3
+
+        get "/api/v1/teams"
+        expect(Team.count).to eq 3
     end
 end


### PR DESCRIPTION
Improvements to the /api/v1/teams endpoint

1. Validates uniqueness of team.abbr column
2. Makes sure to upsert Team records when calling NHL Stats API
3. Allows for sorting of teams based on name and inaugural year