### PR TITLE
Teams index filters

### DIFF
--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -2,6 +2,10 @@ class Api::V1::TeamsController < ApplicationController
     def index
         TeamsFacade.upsert_teams
         teams = Team
+            .where(name_filter)
+            .where(abbr_filter)
+            .where(division_filter)
+            .where(conference_filter)
             .order(sort_mappings[team_params[:sort]])
             .all
         render json: teams, status: 200, each_serializer: TeamSerializer
@@ -10,7 +14,23 @@ class Api::V1::TeamsController < ApplicationController
     private
 
         def team_params
-            params.permit(:sort)
+            params.permit(:sort, :name, :abbr, :division, :conference)
+        end
+
+        def name_filter
+            ['lower(name) = ?', team_params[:name].strip.downcase] unless team_params[:name].blank?
+        end
+
+        def abbr_filter
+            ['lower(abbr) = ?', team_params[:abbr].strip.downcase] unless team_params[:abbr].blank?
+        end
+
+        def division_filter
+            ['division ILIKE ?', "%#{team_params[:division].strip.downcase}%"] unless team_params[:division].blank?
+        end
+
+        def conference_filter
+            ['conference ILIKE ?', "%#{team_params[:conference].strip.downcase}%"] unless team_params[:conference].blank?
         end
 
         def sort_mappings

--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::TeamsController < ApplicationController
         end
 
         def name_filter
-            ['lower(name) = ?', team_params[:name].strip.downcase] unless team_params[:name].blank?
+            ['name ILIKE ?', "%#{team_params[:name].strip.downcase}%"] unless team_params[:name].blank?
         end
 
         def abbr_filter

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,7 +2,7 @@ class Team < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :abbr
   validates_presence_of :external_url
-  validates_uniqueness_of :abbr
+  validates_uniqueness_of :abbr, case_sensitive: false
 
   has_many :players
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -7,7 +7,7 @@ describe Team, type: :model do
     it {should validate_presence_of(:external_url)} 
 
     subject {Team.new(name:"Avs", abbr: "COL", external_url:"/avs")}
-    it {should validate_uniqueness_of(:abbr)} 
+    it {should validate_uniqueness_of(:abbr).case_insensitive} 
     
     it {should_not validate_presence_of(:division)} 
     it {should_not validate_presence_of(:conference)} 

--- a/spec/requests/api/v1/teams/index_spec.rb
+++ b/spec/requests/api/v1/teams/index_spec.rb
@@ -79,4 +79,88 @@ describe "Teams Index" do
         expect(team_2_json["inaugural_year"]).to eq 1979
         expect(team_3_json["inaugural_year"]).to eq 1909
     end
+
+    it "can filter results by team name" do
+        get "/api/v1/teams", params: {name: 'Colorado Avalanche'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+
+        # Allow case insensitive value:
+        get "/api/v1/teams", params: {name: 'COLORADO avalanche'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+    end
+
+    it "can filter results by team abbr" do
+        get "/api/v1/teams", params: {abbr: 'COL'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+        expect(team_1_json["abbr"]).to eq "COL"
+
+        # Allow case insensitive value with extra whitespace:
+        get "/api/v1/teams", params: {abbr: '   col   '}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+        expect(team_1_json["abbr"]).to eq "COL"
+    end
+
+    it "can filter results by team division (string ILIKE matching)" do
+        get "/api/v1/teams", params: {division: 'honda WEST'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+        expect(team_1_json["abbr"]).to eq "COL"
+        expect(team_1_json["division"]).to eq "Honda West"
+        
+        get "/api/v1/teams", params: {division: 'west'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+        expect(team_1_json["abbr"]).to eq "COL"
+        expect(team_1_json["division"]).to eq "Honda West"
+    end
+
+    it "can filter results by team conference (string ILIKE matching)" do
+        get "/api/v1/teams", params: {conference: 'Western'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+        expect(team_1_json["abbr"]).to eq "COL"
+        expect(team_1_json["conference"]).to eq "Western"
+
+        get "/api/v1/teams", params: {conference: 'WEST'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+        expect(team_1_json["abbr"]).to eq "COL"
+        expect(team_1_json["conference"]).to eq "Western"
+    end
 end

--- a/spec/requests/api/v1/teams/index_spec.rb
+++ b/spec/requests/api/v1/teams/index_spec.rb
@@ -80,7 +80,7 @@ describe "Teams Index" do
         expect(team_3_json["inaugural_year"]).to eq 1909
     end
 
-    it "can filter results by team name" do
+    it "can filter results by team name (string ILIKE matching)" do
         get "/api/v1/teams", params: {name: 'Colorado Avalanche'}
 
         teams_json = JSON.parse(response.body)
@@ -91,6 +91,14 @@ describe "Teams Index" do
 
         # Allow case insensitive value:
         get "/api/v1/teams", params: {name: 'COLORADO avalanche'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+
+        get "/api/v1/teams", params: {name: 'avalanche'}
 
         teams_json = JSON.parse(response.body)
         expect(teams_json.count).to eq 1


### PR DESCRIPTION
Adds filtering functionality to the `/api/v1/teams` endpoint by name, abbr, division, and conference.