### PR TITLE
Save team searches

### DIFF
--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::TeamsController < ApplicationController
     def index
-        TeamsFacade.upsert_teams
+        TeamsFacade.upsert_teams # TODO: try to minimize the DB writes happening in here
+        TeamSearchesFacade.update_searches(team_params)
         teams = Team
             .where(name_filter)
             .where(abbr_filter)

--- a/app/facades/team_searches_facade.rb
+++ b/app/facades/team_searches_facade.rb
@@ -1,0 +1,16 @@
+class TeamSearchesFacade
+    def self.update_searches(params)
+        if params.empty?
+            return 
+        end
+        team_search = TeamSearch.find_or_initialize_by(
+            name: params[:name],
+            abbr: params[:abbr],
+            division: params[:division],
+            conference: params[:conference],
+        )
+        team_search.frequency += 1
+        team_search.save
+        team_search
+    end
+end

--- a/app/models/team_search.rb
+++ b/app/models/team_search.rb
@@ -1,4 +1,4 @@
 class TeamSearch < ApplicationRecord
-  validates_presence_of :name
   validates_presence_of :frequency
+  validates_uniqueness_of :name, scope: [:abbr, :division, :conference], case_sensitive: false
 end

--- a/db/migrate/20210620190218_update_team_search.rb
+++ b/db/migrate/20210620190218_update_team_search.rb
@@ -1,0 +1,17 @@
+class UpdateTeamSearch < ActiveRecord::Migration[6.1]
+  def up
+    change_column :team_searches, :name, :citext, :null => true
+    change_column :team_searches, :abbr, :citext
+    change_column :team_searches, :division, :citext
+    change_column :team_searches, :conference, :citext
+    add_index :team_searches, [:name, :abbr, :division, :conference], unique: true, name: "ix_unique_team_search"
+  end
+
+  def down
+    change_column :team_searches, :name, :string, :null => false
+    change_column :team_searches, :abbr, :string
+    change_column :team_searches, :division, :string
+    change_column :team_searches, :conference, :string
+    remove_index :team_searches, name: "ix_unique_team_search"
+  end
+end

--- a/db/migrate/20210620205830_update_search_frequency_default.rb
+++ b/db/migrate/20210620205830_update_search_frequency_default.rb
@@ -1,0 +1,11 @@
+class UpdateSearchFrequencyDefault < ActiveRecord::Migration[6.1]
+  def up
+    change_column :team_searches, :frequency, :integer, :default => 0
+    change_column :roster_searches, :frequency, :integer, :default => 0
+  end
+
+  def down
+    change_column :team_searches, :frequency, :integer, :default => 1
+    change_column :roster_searches, :frequency, :integer, :default => 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_20_010438) do
+ActiveRecord::Schema.define(version: 2021_06_20_190218) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "players", force: :cascade do |t|
@@ -40,12 +41,13 @@ ActiveRecord::Schema.define(version: 2021_06_20_010438) do
 
   create_table "team_searches", force: :cascade do |t|
     t.integer "frequency", default: 1, null: false
-    t.string "name", null: false
-    t.string "abbr"
-    t.string "division"
-    t.string "conference"
+    t.citext "name"
+    t.citext "abbr"
+    t.citext "division"
+    t.citext "conference"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["name", "abbr", "division", "conference"], name: "ix_unique_team_search", unique: true
   end
 
   create_table "teams", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_20_190218) do
+ActiveRecord::Schema.define(version: 2021_06_20_205830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_190218) do
   end
 
   create_table "roster_searches", force: :cascade do |t|
-    t.integer "frequency", default: 1, null: false
+    t.integer "frequency", default: 0, null: false
     t.string "team_abbr", null: false
     t.string "position"
     t.integer "jersey_number"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2021_06_20_190218) do
   end
 
   create_table "team_searches", force: :cascade do |t|
-    t.integer "frequency", default: 1, null: false
+    t.integer "frequency", default: 0, null: false
     t.citext "name"
     t.citext "abbr"
     t.citext "division"

--- a/spec/models/team_search_spec.rb
+++ b/spec/models/team_search_spec.rb
@@ -2,10 +2,24 @@ require "rails_helper"
 
 describe TeamSearch, type: :model do
   describe "validations" do
-    it {should validate_presence_of(:name)} 
     it {should validate_presence_of(:frequency)}  
     it {should_not validate_presence_of(:abbr)} 
     it {should_not validate_presence_of(:division)} 
-    it {should_not validate_presence_of(:conference)} 
+    it {should_not validate_presence_of(:conference)}
+
+    subject {TeamSearch.new(name: "Avs", abbr: "COL", division: 'west')}
+    it {should validate_uniqueness_of(:name).scoped_to(:abbr, :division, :conference).case_insensitive}
+
+    it "cannot create TeamSearch with duplicate search terms (case insensitive)" do
+      search_1 = TeamSearch.create(abbr: 'COL', division: 'WEST')
+      search_2 = TeamSearch.create(abbr: 'col', division: 'west')
+      search_3 = TeamSearch.create(name: 'aval', conference: 'west')
+      search_4 = TeamSearch.create(name: 'aval', conference: 'WEST')
+
+      expect(search_1.save).to be(true) 
+      expect(search_2.save).to be(false) 
+      expect(search_3.save).to be(true) 
+      expect(search_4.save).to be(false) 
+    end
   end
 end

--- a/spec/models/team_search_spec.rb
+++ b/spec/models/team_search_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 describe TeamSearch, type: :model do
   describe "validations" do
-    it {should validate_presence_of(:frequency)}  
+    it {should validate_presence_of(:frequency)}
+
+    it {should_not validate_presence_of(:name)} 
     it {should_not validate_presence_of(:abbr)} 
     it {should_not validate_presence_of(:division)} 
     it {should_not validate_presence_of(:conference)}

--- a/spec/requests/api/v1/teams/index_with_team_search_spec.rb
+++ b/spec/requests/api/v1/teams/index_with_team_search_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe "Teams Index endpoint upserts TeamSearch records" do
+    before :each do
+        fixture_json = File.read('spec/fixtures/teams_no_roster.json')
+        @stub_team_request = stub_request(:get, "https://statsapi.web.nhl.com/api/v1/teams").
+            to_return(status: 200, body: fixture_json)
+    end
+
+    it "can filter results by query params and create a unique TeamSearch record" do
+        get "/api/v1/teams", params: {name: 'Colorado Avalanche', conference: 'west'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json.count).to eq 1
+        team_1_json = teams_json[0]
+        expect(team_1_json["name"]).to eq "Colorado Avalanche"
+
+        team_searches = TeamSearch.all
+        search_1 = team_searches[0]
+
+        expect(team_searches.length).to eq 1
+        expect(search_1.name).to eq 'Colorado Avalanche'
+        expect(search_1.conference).to eq 'west'
+        expect(search_1.frequency).to eq 1
+
+        # If the same request is made again, frequency for that TeamSearch should be incremented:
+
+        get "/api/v1/teams", params: {name: 'colorado avalanche', conference: 'WEST'} # Note case insensitivity
+        team_searches = TeamSearch.all
+        search_1 = team_searches[0]
+
+        expect(team_searches.length).to eq 1
+        expect(search_1.name).to eq 'Colorado Avalanche'
+        expect(search_1.frequency).to eq 2
+
+        get "/api/v1/teams", params: {division: 'WEST'}
+        team_searches = TeamSearch.all
+        search_1, search_2 = team_searches
+        expect(search_1.frequency).to eq 2
+        expect(search_2.frequency).to eq 1
+
+        # With no query params, the TeamSearch table should be left alone:
+        get "/api/v1/teams"
+        team_searches = TeamSearch.all
+        search_1, search_2 = team_searches
+        expect(search_1.frequency).to eq 2
+        expect(search_2.frequency).to eq 1
+    end
+end


### PR DESCRIPTION
Adds functionality so when a user does a `GET /api/v1/teams` with filtering query params (name, abbr, division, conference) those params will be stored in a TeamSearch record to allow for analytics (just tracking frequency for now).

* Adds a composite index on TeamSearch to validate uniqueness of name, abbr, division, conference search combo (case insenstive as well using `citext` column type).
* Also makes the frequency default value 0 (I had it at 1 originally).