### PR TITLE
Players index filters

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -29,11 +29,11 @@ class Api::V1::PlayersController < ApplicationController
         end
 
         def first_name_filter
-            ['first_name ILIKE ?', "%#{player_params[:first_name].strip.downcase}%"] unless player_params[:first_name].blank?
+            ['first_name ILIKE ?', "%#{player_params[:first_name].strip}%"] unless player_params[:first_name].blank?
         end
 
         def last_name_filter
-            ['last_name ILIKE ?', "%#{player_params[:last_name].strip.downcase}%"] unless player_params[:last_name].blank?
+            ['last_name ILIKE ?', "%#{player_params[:last_name].strip}%"] unless player_params[:last_name].blank?
         end
 
         def position_filter

--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -6,6 +6,10 @@ class Api::V1::PlayersController < ApplicationController
             @team.players = TeamsFacade.get_roster(@team)
         end
         players = @team.players
+            .where(first_name_filter)
+            .where(last_name_filter)
+            .where(position_filter)
+            .where(jersey_filter)
             .order(sort_mappings[player_params[:sort]])
             .all
 
@@ -14,7 +18,7 @@ class Api::V1::PlayersController < ApplicationController
 
     private
         def player_params
-            params.permit(:team_abbr, :sort)
+            params.permit(:team_abbr, :sort, :first_name, :last_name, :position, :jersey)
         end
 
         def find_team
@@ -22,6 +26,22 @@ class Api::V1::PlayersController < ApplicationController
             if not @team
                 render json: {:error => "Cannot find team #{player_params[:team_abbr]}"}, status: 404
             end
+        end
+
+        def first_name_filter
+            ['first_name ILIKE ?', "%#{player_params[:first_name].strip.downcase}%"] unless player_params[:first_name].blank?
+        end
+
+        def last_name_filter
+            ['last_name ILIKE ?', "%#{player_params[:last_name].strip.downcase}%"] unless player_params[:last_name].blank?
+        end
+
+        def position_filter
+            ['lower(position) = ?', player_params[:position].strip.downcase] unless player_params[:position].blank?
+        end
+
+        def jersey_filter
+            ['jersey_number = ?', player_params[:jersey]] unless player_params[:jersey].blank?
         end
 
         def sort_mappings

--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::TeamsController < ApplicationController
         end
 
         def name_filter
-            ['name ILIKE ?', "%#{team_params[:name].strip.downcase}%"] unless team_params[:name].blank?
+            ['name ILIKE ?', "%#{team_params[:name].strip}%"] unless team_params[:name].blank?
         end
 
         def abbr_filter
@@ -27,11 +27,11 @@ class Api::V1::TeamsController < ApplicationController
         end
 
         def division_filter
-            ['division ILIKE ?', "%#{team_params[:division].strip.downcase}%"] unless team_params[:division].blank?
+            ['division ILIKE ?', "%#{team_params[:division].strip}%"] unless team_params[:division].blank?
         end
 
         def conference_filter
-            ['conference ILIKE ?', "%#{team_params[:conference].strip.downcase}%"] unless team_params[:conference].blank?
+            ['conference ILIKE ?', "%#{team_params[:conference].strip}%"] unless team_params[:conference].blank?
         end
 
         def sort_mappings

--- a/spec/requests/api/v1/players/index_spec.rb
+++ b/spec/requests/api/v1/players/index_spec.rb
@@ -91,4 +91,46 @@ describe 'Players Index' do
         expect(player_2_json["jersey_number"]).to eq 29
         expect(player_3_json["jersey_number"]).to eq 8
     end
+
+    it "can filter by first_name" do
+        get "/api/v1/teams/#{@avs.abbr}/players", params: {first_name: 'cale'}
+
+        players_json = JSON.parse(response.body)
+        expect(players_json.count).to eq 1
+        expect(players_json[0]["first_name"]).to eq "Cale"
+        expect(players_json[0]["last_name"]).to eq "Makar"
+    end
+
+    it "can filter by last_name" do
+        get "/api/v1/teams/#{@avs.abbr}/players", params: {last_name: 'Mack'}
+
+        players_json = JSON.parse(response.body)
+        expect(players_json.count).to eq 1
+        expect(players_json[0]["first_name"]).to eq "Nathan"
+        expect(players_json[0]["last_name"]).to eq "MacKinnon"
+    end
+
+    it "can filter by position" do
+        get "/api/v1/teams/#{@avs.abbr}/players", params: {position: 'C'}
+
+        players_json = JSON.parse(response.body)
+        expect(players_json.count).to eq 1
+        expect(players_json[0]["first_name"]).to eq "Nathan"
+        expect(players_json[0]["last_name"]).to eq "MacKinnon"
+        expect(players_json[0]["position"]).to eq "C"
+
+        # No goalies in the fixture data
+        get "/api/v1/teams/#{@avs.abbr}/players", params: {position: 'G'}
+        players_json = JSON.parse(response.body)
+        expect(players_json).to eq []
+    end
+
+    it "can filter by jersey_number" do
+        get "/api/v1/teams/#{@avs.abbr}/players", params: {jersey: 92}
+
+        players_json = JSON.parse(response.body)
+        expect(players_json.count).to eq 1
+        expect(players_json[0]["last_name"]).to eq "Landeskog"
+        expect(players_json[0]["jersey_number"]).to eq 92
+    end
 end


### PR DESCRIPTION
Adds the ability to filter the `GET /api/v1/teams/:abbr/players` results by first_name, last_name, position, and jersey number.