### PR TITLE
Roster search data

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::PlayersController < ApplicationController
         if @team.players.empty?
             @team.players = TeamsFacade.get_roster(@team)
         end
+        RosterSearchesFacade.update_searches(player_params)
         players = @team.players
             .where(first_name_filter)
             .where(last_name_filter)

--- a/app/facades/roster_searches_facade.rb
+++ b/app/facades/roster_searches_facade.rb
@@ -1,0 +1,16 @@
+class RosterSearchesFacade
+    def self.update_searches(params)
+        if params.empty?
+            return 
+        end
+        roster_search = RosterSearch.find_or_initialize_by(
+            team_abbr: params[:team_abbr],
+            first_name: params[:first_name],
+            last_name: params[:last_name],
+            position: params[:position],
+        )
+        roster_search.frequency += 1
+        roster_search.save
+        roster_search
+    end
+end

--- a/app/models/roster_search.rb
+++ b/app/models/roster_search.rb
@@ -1,4 +1,5 @@
 class RosterSearch < ApplicationRecord
   validates_presence_of :team_abbr
   validates_presence_of :frequency
+  validates_uniqueness_of :team_abbr, scope: [:first_name, :last_name, :position, :jersey_number], case_sensitive: false
 end 

--- a/db/migrate/20210620233407_unique_roster_search.rb
+++ b/db/migrate/20210620233407_unique_roster_search.rb
@@ -1,0 +1,17 @@
+class UniqueRosterSearch < ActiveRecord::Migration[6.1]
+  def up
+    change_column :roster_searches, :team_abbr, :citext
+    change_column :roster_searches, :first_name, :citext
+    change_column :roster_searches, :last_name, :citext
+    change_column :roster_searches, :position, :citext
+    add_index :roster_searches, [:team_abbr, :first_name, :last_name, :position], unique: true, name: "ix_unique_roster_search"
+  end
+
+  def down
+    change_column :roster_searches, :team_abbr, :string
+    change_column :roster_searches, :first_name, :string
+    change_column :roster_searches, :last_name, :string
+    change_column :roster_searches, :position, :string
+    remove_index :roster_searches, name: "ix_unique_roster_search"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_20_205830) do
+ActiveRecord::Schema.define(version: 2021_06_20_233407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -30,13 +30,14 @@ ActiveRecord::Schema.define(version: 2021_06_20_205830) do
 
   create_table "roster_searches", force: :cascade do |t|
     t.integer "frequency", default: 0, null: false
-    t.string "team_abbr", null: false
-    t.string "position"
+    t.citext "team_abbr", null: false
+    t.citext "position"
     t.integer "jersey_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "first_name"
-    t.string "last_name"
+    t.citext "first_name"
+    t.citext "last_name"
+    t.index ["team_abbr", "first_name", "last_name", "position"], name: "ix_unique_roster_search", unique: true
   end
 
   create_table "team_searches", force: :cascade do |t|

--- a/spec/models/roster_search_spec.rb
+++ b/spec/models/roster_search_spec.rb
@@ -9,5 +9,16 @@ describe RosterSearch, type: :model do
     it {should_not validate_presence_of(:last_name)}
     it {should_not validate_presence_of(:position)}
     it {should_not validate_presence_of(:jersey_number)}
+    
+    subject {RosterSearch.new(team_abbr: "COL", position: 'C')}
+    it {should validate_uniqueness_of(:team_abbr).scoped_to(:first_name, :last_name, :position, :jersey_number).case_insensitive}
+    
+    it "cannot create RosterSearch with duplicate search terms (case insensitive)" do
+      search_1 = RosterSearch.create(team_abbr: 'COL', last_name: 'Mack')
+      search_2 = RosterSearch.create(team_abbr: 'col', last_name: 'MACK')
+
+      expect(search_1.save).to be(true) 
+      expect(search_2.save).to be(false) 
+    end
   end
 end

--- a/spec/requests/api/v1/players/index_spec_with_roster_search_spec.rb
+++ b/spec/requests/api/v1/players/index_spec_with_roster_search_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe 'Players Index' do
+    before :each do
+        fixture_json = File.read('spec/fixtures/avs_with_roster.json')
+        @stub_team_request = stub_request(:get, "https://statsapi.web.nhl.com/api/v1/teams/21/roster").
+            to_return(status: 200, body: fixture_json)
+
+        @avs = Team.create!(
+            id: 21,
+            name: "Colorado Avalanche",
+            abbr: "COL",
+            external_url: "https://statsapi.web.nhl.com/api/v1/teams/21",
+        )
+    end
+
+    it "can filter results by query params and create a unique RosterSearch record" do
+        get "/api/v1/teams/#{@avs.abbr}/players", params: {first_name: 'cale', position: 'D'}
+
+        players_json = JSON.parse(response.body)
+        expect(players_json.count).to eq 1
+        expect(players_json[0]["first_name"]).to eq "Cale"
+        expect(players_json[0]["last_name"]).to eq "Makar"
+
+        roster_searches = RosterSearch.all
+        search_1 = roster_searches[0]
+
+        expect(search_1.team_abbr).to eq 'COL'
+        expect(search_1.first_name).to eq 'cale'
+        expect(search_1.position).to eq 'D'
+        expect(search_1.frequency).to eq 1
+
+        # If the same request is made again, frequency for that RosterSearch should be incremented:
+        get "/api/v1/teams/#{@avs.abbr}/players", params: {first_name: 'CALE', position: 'd'}
+        roster_searches = RosterSearch.all
+        search_1 = roster_searches[0]
+        expect(search_1.frequency).to eq 2
+
+        get "/api/v1/teams/#{@avs.abbr}/players", params: {position: 'D'}
+        roster_searches = RosterSearch.all
+        search_1, search_2 = roster_searches
+        expect(search_1.frequency).to eq 2
+        expect(search_2.frequency).to eq 1
+
+        # With no query params, the RosterSearch table should be left alone:
+        get "/api/v1/teams/#{@avs.abbr}/players"
+        roster_searches = RosterSearch.all
+        search_1, search_2 = roster_searches
+        expect(search_1.frequency).to eq 2
+        expect(search_2.frequency).to eq 1
+    end
+end


### PR DESCRIPTION
Adds the functionality to populate the RosterSearches table when users search for players with query params from `/api/v1/teams/:abbr/players` endpoint.

* Validates uniqueness of RosterSearch terms using citext and a unique composite index