### PR TITLE
Team searches teams

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,4 +232,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/app/controllers/api/v1/team_searches_controller.rb
+++ b/app/controllers/api/v1/team_searches_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::TeamSearchesController < ApplicationController
     def index
-        team_searches = TeamSearch.order("frequency DESC").all
+        team_searches = TeamSearch
+            .order("frequency DESC")
+            .includes(:teams)
+            .all
         render json: team_searches, status: 200, each_serializer: TeamSearchSerializer  
     end
 end

--- a/app/controllers/api/v1/team_searches_controller.rb
+++ b/app/controllers/api/v1/team_searches_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::TeamSearchesController < ApplicationController
     def index
         team_searches = TeamSearch.order("frequency DESC").all
-        render json: team_searches, status: 200
+        render json: team_searches, status: 200, each_serializer: TeamSearchSerializer  
     end
 end

--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::TeamsController < ApplicationController
     def index
         TeamsFacade.upsert_teams # TODO: try to minimize the DB writes happening in here
-        TeamSearchesFacade.update_searches(team_params)
         teams = Team
             .where(name_filter)
             .where(abbr_filter)
@@ -9,6 +8,7 @@ class Api::V1::TeamsController < ApplicationController
             .where(conference_filter)
             .order(sort_mappings[team_params[:sort]])
             .all
+        TeamSearchesFacade.update_searches(team_params, teams)
         render json: teams, status: 200, each_serializer: TeamSerializer
     end
 

--- a/app/facades/team_searches_facade.rb
+++ b/app/facades/team_searches_facade.rb
@@ -1,5 +1,5 @@
 class TeamSearchesFacade
-    def self.update_searches(params)
+    def self.update_searches(params, teams)
         if params.empty?
             return 
         end
@@ -10,6 +10,7 @@ class TeamSearchesFacade
             conference: params[:conference],
         )
         team_search.frequency += 1
+        team_search.teams = teams
         team_search.save
         team_search
     end

--- a/app/models/team_search.rb
+++ b/app/models/team_search.rb
@@ -1,4 +1,7 @@
 class TeamSearch < ApplicationRecord
   validates_presence_of :frequency
   validates_uniqueness_of :name, scope: [:abbr, :division, :conference], case_sensitive: false
+
+  has_many :team_search_teams
+  has_many :teams, through: :team_search_teams
 end

--- a/app/models/team_search_team.rb
+++ b/app/models/team_search_team.rb
@@ -1,0 +1,4 @@
+class TeamSearchTeam < ApplicationRecord
+    belongs_to :team
+    belongs_to :team_search
+end

--- a/app/serializers/team_search_serializer.rb
+++ b/app/serializers/team_search_serializer.rb
@@ -1,0 +1,5 @@
+class TeamSearchSerializer < ActiveModel::Serializer
+    attributes :id, :frequency, :name, :abbr, :division, :conference
+    has_many :teams, through: :team_search_teams
+end
+  

--- a/db/migrate/20210630040633_create_team_search_team.rb
+++ b/db/migrate/20210630040633_create_team_search_team.rb
@@ -1,0 +1,10 @@
+class CreateTeamSearchTeam < ActiveRecord::Migration[6.1]
+  def change
+    create_table :team_search_teams do |t|
+      t.references :team, null: true, foreign_key: true
+      t.references :team_search, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_20_233407) do
+ActiveRecord::Schema.define(version: 2021_06_30_040633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -40,6 +40,15 @@ ActiveRecord::Schema.define(version: 2021_06_20_233407) do
     t.index ["team_abbr", "first_name", "last_name", "position"], name: "ix_unique_roster_search", unique: true
   end
 
+  create_table "team_search_teams", force: :cascade do |t|
+    t.bigint "team_id"
+    t.bigint "team_search_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["team_id"], name: "index_team_search_teams_on_team_id"
+    t.index ["team_search_id"], name: "index_team_search_teams_on_team_search_id"
+  end
+
   create_table "team_searches", force: :cascade do |t|
     t.integer "frequency", default: 0, null: false
     t.citext "name"
@@ -63,4 +72,6 @@ ActiveRecord::Schema.define(version: 2021_06_20_233407) do
   end
 
   add_foreign_key "players", "teams"
+  add_foreign_key "team_search_teams", "team_searches"
+  add_foreign_key "team_search_teams", "teams"
 end

--- a/spec/models/team_search_spec.rb
+++ b/spec/models/team_search_spec.rb
@@ -24,4 +24,8 @@ describe TeamSearch, type: :model do
       expect(search_4.save).to be(false) 
     end
   end
+
+  describe "Relationships" do
+    it {should have_many(:teams).through(:team_search_teams)}
+  end
 end

--- a/spec/requests/api/v1/team_searches/index_spec.rb
+++ b/spec/requests/api/v1/team_searches/index_spec.rb
@@ -4,6 +4,9 @@ describe 'Searches Index' do
     it "can show all the current team and roster search data with frequencies" do
         search_1 = TeamSearch.create!(division: "north", name: "leafs", frequency: 1)
         search_2 = TeamSearch.create!(division: "west", frequency: 5)
+        west_team_1 = Team.create!(name: "Colorado Avalanche", abbr: "COL", external_url: "hi")
+        west_team_2 = Team.create!(name: "Los Angeles Kings", abbr: "LAK", external_url: "hi_there")
+        search_2.teams = [west_team_1, west_team_2]
         
         get "/api/v1/team_searches"
         
@@ -13,5 +16,9 @@ describe 'Searches Index' do
         expect(team_searches_json.length).to eq 2
         expect(team_searches_json[0]["division"]).to eq "west"
         expect(team_searches_json[0]["frequency"]).to eq 5
+        expect(team_searches_json[0]["teams"]).to be_a Array
+        expect(team_searches_json[0]["teams"].count).to eq 2
+        
+        expect(team_searches_json[1]["teams"].count).to eq 0
     end
 end

--- a/spec/requests/api/v1/teams/index_with_team_search_spec.rb
+++ b/spec/requests/api/v1/teams/index_with_team_search_spec.rb
@@ -54,4 +54,18 @@ describe "Teams Index endpoint upserts TeamSearch records" do
         expect(search_1.frequency).to eq 2
         expect(search_2.frequency).to eq 1
     end
+
+    it "will return an empty array if no teams match filter params" do
+        get "/api/v1/teams", params: {name: 'maple leafs'}
+
+        teams_json = JSON.parse(response.body)
+        expect(teams_json).to eq []
+
+        team_searches = TeamSearch.all
+        search_1 = team_searches[0]
+
+        expect(search_1.name).to eq 'maple leafs'
+        expect(search_1.frequency).to eq 1
+        expect(search_1.teams).to eq []
+    end
 end

--- a/spec/requests/api/v1/teams/index_with_team_search_spec.rb
+++ b/spec/requests/api/v1/teams/index_with_team_search_spec.rb
@@ -23,6 +23,10 @@ describe "Teams Index endpoint upserts TeamSearch records" do
         expect(search_1.conference).to eq 'west'
         expect(search_1.frequency).to eq 1
 
+        expect(search_1.teams.count).to eq 1
+        expect(search_1.teams[0]).to be_a(Team)
+        expect(search_1.teams[0].name).to eq "Colorado Avalanche"
+
         # If the same request is made again, frequency for that TeamSearch should be incremented:
 
         get "/api/v1/teams", params: {name: 'colorado avalanche', conference: 'WEST'} # Note case insensitivity
@@ -32,6 +36,10 @@ describe "Teams Index endpoint upserts TeamSearch records" do
         expect(team_searches.length).to eq 1
         expect(search_1.name).to eq 'Colorado Avalanche'
         expect(search_1.frequency).to eq 2
+
+        expect(search_1.teams.count).to eq 1
+        expect(search_1.teams[0]).to be_a(Team)
+        expect(search_1.teams[0].name).to eq "Colorado Avalanche"
 
         get "/api/v1/teams", params: {division: 'WEST'}
         team_searches = TeamSearch.all


### PR DESCRIPTION
Addresses part of issues: 
https://github.com/leepuppychow/hockey_api/issues/29
https://github.com/leepuppychow/hockey_api/issues/19

* Creates many-many relationship from TeamSearch --> TeamSearchTeams --> Team
* Updates TeamSearchFacade to associate the TeamSearch record with any Teams found
* Updates the JSON returned from `/api/v1/team_searches` to show the TeamSearch().teams array

TODO:
* Follow similar pattern to create relationship for RosterSearch --> RosterSearchPlayers --> Player
