### PR TITLE
Roster search players

### DIFF
--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -5,7 +5,6 @@ class Api::V1::PlayersController < ApplicationController
         if @team.players.empty?
             @team.players = TeamsFacade.get_roster(@team)
         end
-        RosterSearchesFacade.update_searches(player_params)
         players = @team.players
             .where(first_name_filter)
             .where(last_name_filter)
@@ -13,7 +12,8 @@ class Api::V1::PlayersController < ApplicationController
             .where(jersey_filter)
             .order(sort_mappings[player_params[:sort]])
             .all
-
+        RosterSearchesFacade.update_searches(player_params, players)
+        
         render json: players, status: 200, each_serializer: PlayerSerializer
     end
 

--- a/app/controllers/api/v1/roster_searches_controller.rb
+++ b/app/controllers/api/v1/roster_searches_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::RosterSearchesController < ApplicationController
     def index
-        roster_searches = RosterSearch.order("frequency DESC").all
+        roster_searches = RosterSearch
+            .includes(:players)
+            .order("frequency DESC")
+            .all
         render json: roster_searches, status: 200, each_serializer: RosterSearchSerializer
     end
 end

--- a/app/controllers/api/v1/roster_searches_controller.rb
+++ b/app/controllers/api/v1/roster_searches_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::RosterSearchesController < ApplicationController
     def index
         roster_searches = RosterSearch.order("frequency DESC").all
-        render json: roster_searches, status: 200
+        render json: roster_searches, status: 200, each_serializer: RosterSearchSerializer
     end
 end

--- a/app/facades/roster_searches_facade.rb
+++ b/app/facades/roster_searches_facade.rb
@@ -1,5 +1,5 @@
 class RosterSearchesFacade
-    def self.update_searches(params)
+    def self.update_searches(params, players)
         if params.empty?
             return 
         end
@@ -11,6 +11,7 @@ class RosterSearchesFacade
             jersey_number: params[:jersey],
         )
         roster_search.frequency += 1
+        roster_search.players = players
         roster_search.save
         roster_search
     end

--- a/app/models/roster_search.rb
+++ b/app/models/roster_search.rb
@@ -2,4 +2,7 @@ class RosterSearch < ApplicationRecord
   validates_presence_of :team_abbr
   validates_presence_of :frequency
   validates_uniqueness_of :team_abbr, scope: [:first_name, :last_name, :position, :jersey_number], case_sensitive: false
+
+  has_many :roster_search_players
+  has_many :players, through: :roster_search_players
 end 

--- a/app/models/roster_search_player.rb
+++ b/app/models/roster_search_player.rb
@@ -1,0 +1,4 @@
+class RosterSearchPlayer < ApplicationRecord
+    belongs_to :player
+    belongs_to :roster_search
+end

--- a/app/serializers/roster_search_serializer.rb
+++ b/app/serializers/roster_search_serializer.rb
@@ -1,0 +1,5 @@
+class RosterSearchSerializer < ActiveModel::Serializer
+    attributes :id, :frequency, :team_abbr, :position, :jersey_number, :first_name, :last_name
+    has_many :players, through: :roster_search_players
+end
+  

--- a/db/migrate/20210630164338_create_roster_search_player.rb
+++ b/db/migrate/20210630164338_create_roster_search_player.rb
@@ -1,0 +1,10 @@
+class CreateRosterSearchPlayer < ActiveRecord::Migration[6.1]
+  def change
+    create_table :roster_search_players do |t|
+      t.references :player, null: true, foreign_key: true
+      t.references :roster_search, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_040633) do
+ActiveRecord::Schema.define(version: 2021_06_30_164338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -26,6 +26,15 @@ ActiveRecord::Schema.define(version: 2021_06_30_040633) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["team_id"], name: "index_players_on_team_id"
+  end
+
+  create_table "roster_search_players", force: :cascade do |t|
+    t.bigint "player_id"
+    t.bigint "roster_search_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["player_id"], name: "index_roster_search_players_on_player_id"
+    t.index ["roster_search_id"], name: "index_roster_search_players_on_roster_search_id"
   end
 
   create_table "roster_searches", force: :cascade do |t|
@@ -72,6 +81,8 @@ ActiveRecord::Schema.define(version: 2021_06_30_040633) do
   end
 
   add_foreign_key "players", "teams"
+  add_foreign_key "roster_search_players", "players"
+  add_foreign_key "roster_search_players", "roster_searches"
   add_foreign_key "team_search_teams", "team_searches"
   add_foreign_key "team_search_teams", "teams"
 end

--- a/spec/models/roster_search_spec.rb
+++ b/spec/models/roster_search_spec.rb
@@ -21,4 +21,8 @@ describe RosterSearch, type: :model do
       expect(search_2.save).to be(false) 
     end
   end
+
+  describe "Relationships" do
+    it {should have_many(:players).through(:roster_search_players)}
+  end
 end

--- a/spec/requests/api/v1/players/index_spec_with_roster_search_spec.rb
+++ b/spec/requests/api/v1/players/index_spec_with_roster_search_spec.rb
@@ -30,11 +30,19 @@ describe 'Players Index' do
         expect(search_1.position).to eq 'D'
         expect(search_1.frequency).to eq 1
 
+        expect(search_1.players.count).to eq 1
+        expect(search_1.players[0].first_name).to eq "Cale"
+        expect(search_1.players[0].last_name).to eq "Makar"
+
         # If the same request is made again, frequency for that RosterSearch should be incremented:
         get "/api/v1/teams/#{@avs.abbr}/players", params: {first_name: 'CALE', position: 'd'}
         roster_searches = RosterSearch.all
         search_1 = roster_searches[0]
         expect(search_1.frequency).to eq 2
+
+        expect(search_1.players.count).to eq 1
+        expect(search_1.players[0].first_name).to eq "Cale"
+        expect(search_1.players[0].last_name).to eq "Makar"
 
         get "/api/v1/teams/#{@avs.abbr}/players", params: {position: 'D'}
         roster_searches = RosterSearch.all

--- a/spec/requests/api/v1/roster_searches/index_spec.rb
+++ b/spec/requests/api/v1/roster_searches/index_spec.rb
@@ -2,9 +2,13 @@ require 'rails_helper'
 
 describe 'Searches Index' do
     it "can show all the current team and roster search data with frequencies" do
+        avs = Team.create!(name: "Avs", abbr: "COL", external_url: "/avs")
         search_1 = RosterSearch.create!(team_abbr: "MTL", jersey_number: 33, frequency: 4)
-        search_2 = RosterSearch.create!(team_abbr: "COL", position: "D", frequency: 20)
-        search_3 = RosterSearch.create!(team_abbr: "COL", first_name: "Mack", frequency: 8)
+        search_2 = RosterSearch.create!(team_abbr: "COL", first_name: "Mack", frequency: 8)
+        search_3 = RosterSearch.create!(team_abbr: "COL", position: "D", frequency: 20)
+        defenseman_1 = Player.create!(first_name: "Cale", last_name: "Makar", external_url: "/hi", team: avs)
+        defenseman_2 = Player.create!(first_name: "Devon", last_name: "Toews", external_url: "/hi_there", team: avs)
+        search_3.players = [defenseman_1, defenseman_2]
         
         get "/api/v1/roster_searches"
         
@@ -15,5 +19,11 @@ describe 'Searches Index' do
         expect(roster_searches_json[0]["team_abbr"]).to eq "COL"
         expect(roster_searches_json[0]["position"]).to eq "D"
         expect(roster_searches_json[0]["frequency"]).to eq 20
+
+        expect(roster_searches_json[0]["players"]).to be_a Array
+        expect(roster_searches_json[0]["players"][0]["last_name"]).to eq defenseman_1.last_name
+        expect(roster_searches_json[0]["players"][1]["last_name"]).to eq defenseman_2.last_name
+
+        expect(roster_searches_json[1]["players"]).to eq []
     end
 end


### PR DESCRIPTION
Completes issues:

https://github.com/leepuppychow/hockey_api/issues/29
https://github.com/leepuppychow/hockey_api/issues/19

1. Creates relationship from RosterSearch --> RosterSearchPlayers --> Players
2. When RosterSearch records are upserted, their players data will also be updated
3. `GET /api/v1/roster_searches` will now return the associated players array data
